### PR TITLE
Improve clocking

### DIFF
--- a/btest.c
+++ b/btest.c
@@ -616,7 +616,7 @@ void *test_udp_tx(void *arg) {
 	bzero(buf, pcmd->tx_size-28);
 
 	/* Get current time and add the interval to it */
-	clock_gettime(CLOCK_REALTIME, &nextPacketTime);
+	clock_gettime(CLOCK_MONOTONIC, &nextPacketTime);
 	timespec_dump("gettime: ", &nextPacketTime);
 	while(1) {
 		if (tx_speed_variable && tx_speed_changed) {
@@ -644,7 +644,7 @@ void *test_udp_tx(void *arg) {
 #ifdef __MACH__
 		clock_nanosleep_abstime(&nextPacketTime);
 #else
-		if (clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &nextPacketTime, NULL) < 0) {
+		if (clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &nextPacketTime, NULL) < 0) {
 			perror("clock_nanosleep: ");
 		}
 #endif
@@ -690,7 +690,7 @@ void *test_udp_rx(void *arg) {
 			}
 		}
 		if (nBytes>0) {
-			clock_gettime(CLOCK_REALTIME, &now);
+			clock_gettime(CLOCK_MONOTONIC, &now);
 
 			thisSeq=buf[0];
 			thisSeq=thisSeq * 256 + buf[1];
@@ -815,14 +815,14 @@ int test_udp(struct cmdStruct cmd, int cmdsock, char *remoteIP) {
 	interval.tv_sec=1;
 
 	/* Get current time and add the interval to it */
-	clock_gettime(CLOCK_REALTIME, &nextStatusTime);
+	clock_gettime(CLOCK_MONOTONIC, &nextStatusTime);
 	timespec_add(&nextStatusTime, &interval);
 	recvStats.seq=0;
 	while(1) {
 		int ready;
 		fd_set readfds;
 
-		clock_gettime(CLOCK_REALTIME, &now);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 		timespec_diff(&now, &nextStatusTime, &timeout);
 
 		FD_ZERO(&readfds);
@@ -855,7 +855,7 @@ int test_udp(struct cmdStruct cmd, int cmdsock, char *remoteIP) {
 			}
 		}
 
-		clock_gettime(CLOCK_REALTIME, &now);
+		clock_gettime(CLOCK_MONOTONIC, &now);
 		if (timespec_cmp(&now, &nextStatusTime) > 0) {
 			recvStats.seq++;
 			packStatStr(&recvStats, buffer);

--- a/btest.c
+++ b/btest.c
@@ -590,6 +590,7 @@ void *test_udp_tx(void *arg) {
 	int i;
 	struct timespec interval; /* Interval between packets in nano seconds */
 	struct timespec nextPacketTime;
+	struct timespec now;
 	int tx_speed_variable=0;
 	unsigned long tx_speed;
 
@@ -641,13 +642,16 @@ void *test_udp_tx(void *arg) {
 		}
 		// printf("Sleep until %lu:%lu\n", nextPacketTime.tv_sec, nextPacketTime.tv_nsec);
 		//timespec_dump("sleep until: ", &nextPacketTime);
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		if (now.tv_sec <= nextPacketTime.tv_sec && now.tv_nsec < nextPacketTime.tv_nsec) {
 #ifdef __MACH__
-		clock_nanosleep_abstime(&nextPacketTime);
+			clock_nanosleep_abstime(&nextPacketTime);
 #else
-		if (clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &nextPacketTime, NULL) < 0) {
-			perror("clock_nanosleep: ");
-		}
+			if (clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &nextPacketTime, NULL) < 0) {
+				perror("clock_nanosleep: ");
+			}
 #endif
+		}
 
 		send(udpSocket, buf, pcmd->tx_size-28,0);
 		/*


### PR DESCRIPTION
First of all, CLOCK_REALTIME isn't a good choice for clocking, since it is influenced by system time changes: When I change the system clock 1 minute backwards, we won't send a new packet for 1 minute. CLOCK_MONOTONIC doesn't have that problem, and actually is designed for exactly this kind of usage.

Second, although the documentation says clock_nanosleep() won't do anything if the requested time already passed, on my system, this wasn't the case. So this fixes #12 